### PR TITLE
Resolve backslashes against function matchers

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 var arrify = require('arrify');
 var micromatch = require('micromatch');
+var normalize = require('normalize-path');
 var path = require('path');
 
 var anymatch = function(criteria, value, returnIndex, startIndex, endIndex) {
@@ -54,7 +55,7 @@ var anymatch = function(criteria, value, returnIndex, startIndex, endIndex) {
   }, []);
   if (!negGlobs.length || !micromatch.any(string, negGlobs)) {
     if (path.sep === '\\' && typeof string === 'string') {
-      altString = string.split('\\').join('/');
+      altString = normalize(string);
       altString = altString === string ? null : altString;
       if (altString) altValue = [altString].concat(value.slice(1));
     }

--- a/index.js
+++ b/index.js
@@ -15,10 +15,10 @@ var anymatch = function(criteria, value, returnIndex, startIndex, endIndex) {
   }
   startIndex = startIndex || 0;
   var string = value[0];
-  var altString;
+  var altString, altValue;
   var matched = false;
   var matchIndex = -1;
-  function testCriteria (criterion, index) {
+  function testCriteria(criterion, index) {
     var result;
     switch (toString.call(criterion)) {
     case '[object String]':
@@ -30,6 +30,7 @@ var anymatch = function(criteria, value, returnIndex, startIndex, endIndex) {
       break;
     case '[object Function]':
       result = criterion.apply(null, value);
+      result = result || altValue && criterion.apply(null, altValue);
       break;
     default:
       result = false;
@@ -55,6 +56,7 @@ var anymatch = function(criteria, value, returnIndex, startIndex, endIndex) {
     if (path.sep === '\\' && typeof string === 'string') {
       altString = string.split('\\').join('/');
       altString = altString === string ? null : altString;
+      if (altString) altValue = [altString].concat(value.slice(1));
     }
     matched = crit.slice(startIndex, endIndex).some(testCriteria);
   }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   },
   "dependencies": {
     "arrify": "^1.0.0",
-    "micromatch": "^2.1.5"
+    "micromatch": "^2.1.5",
+    "normalize-path": "^2.0.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",

--- a/test.js
+++ b/test.js
@@ -10,7 +10,7 @@ describe('anymatch', function() {
     'path/anyjs/**/*.js',
     /foo.js$/,
     function(string) {
-      return string.indexOf('bar') !== -1 && string.length > 10;
+      return string.indexOf('/bar') !== -1 && string.length > 10;
     }
   ];
   it('should resolve string matchers', function() {
@@ -175,6 +175,10 @@ describe('anymatch', function() {
     it('should resolve backslashes against regex matchers', function() {
       assert(anymatch(/path\/to\/file\.js/, 'path\\to\\file.js'));
       assert(anymatch(/path\/to\/file\.js/)('path\\to\\file.js'));
+    });
+    it('should resolve backslashes against function matchers', function() {
+      assert(anymatch(matchers, 'path\\to\\bar.js'));
+      assert(anymatch(matchers)('path\\to\\bar.js'));
     });
     it('should still correctly handle forward-slash paths', function() {
       assert(anymatch(matchers, 'path/to/file.js'));


### PR DESCRIPTION
https://github.com/jonschlinkert/micromatch/pull/37 exposed this oversight. Even if relying upon micromatch to do this, user-supplied functions should get the same treatment as everything else.

R= @jonschlinkert 