### PR TITLE
Fixes a bug in IE<=11 when calling toString instead of Object.prototype.toString

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var anymatch = function(criteria, value, returnIndex, startIndex, endIndex) {
   var matchIndex = -1;
   function testCriteria(criterion, index) {
     var result;
-    switch (toString.call(criterion)) {
+    switch (Object.prototype.toString.call(criterion)) {
     case '[object String]':
       result = string === criterion || altString && altString === criterion;
       result = result || micromatch.isMatch(string, criterion);


### PR DESCRIPTION
Tested in IE 11 and Chrome 51.

Ref: http://stackoverflow.com/questions/27053688/ie-11-not-liking-tostring-callvalue